### PR TITLE
Fixed - Always false condition

### DIFF
--- a/src/KenticoCloud/Delivery/Models/ContentItem.php
+++ b/src/KenticoCloud/Delivery/Models/ContentItem.php
@@ -36,7 +36,7 @@ class ContentItem extends Model
     public function getNumber($name)
     {
         $value = $this->getElementValue($name);
-        return floatval($value) !== intval($value) ? floatval($value) : intval($value);
+        return gettype($value) == "double" ? floatval($value) : intval($value);
     }
 
     public function getDateTime($name, $format = null)


### PR DESCRIPTION
This condition was previously always `false`, because `float` value was compared on identity with `integer` value. Now the condition checks whether the type of `$value` is `float` (for historical reason, the check is on string literal `double`).