### PR TITLE
Fixed - Wrong parameters and method calls in UrlBuilder

### DIFF
--- a/src/KenticoCloud/Delivery/UrlBuilder.php
+++ b/src/KenticoCloud/Delivery/UrlBuilder.php
@@ -23,7 +23,7 @@ class UrlBuilder
 
     public function getItemUrl($codename, $query)
     {
-        return $this->buildUrl(sprintf(self::URL_TEMPLATE_ITEM, urlencode($codename)), parameters);
+        return $this->buildUrl(sprintf(self::URL_TEMPLATE_ITEM, urlencode($codename)), $query);
     }
 
     public function getItemsUrl($query = null)
@@ -33,12 +33,12 @@ class UrlBuilder
 
     public function getTypeUrl($codename)
     {
-        return $this->uildUrl(sprintf(self::URL_TEMPLATE_TYPE, urlencode($codename)));
+        return $this->buildUrl(sprintf(self::URL_TEMPLATE_TYPE, urlencode($codename)));
     }
 
     public function getTypesUrl($query)
     {
-        return $this->buildUrl(self::URL_TEMPLATE_TYPES, parameters);
+        return $this->buildUrl(self::URL_TEMPLATE_TYPES, $query);
     }
 
     public function getContentElementUrl($contentTypeCodename, $contentElementCodename)


### PR DESCRIPTION
Fixes issues in `getType*` methods with `buildUrl` method call and also missing `$` signs  in `getItemUrl()` method.