### PR TITLE
Secured production api key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $client = new DeliveryClient('975bf280-fd91-488c-994c-2f04416e5ee3');
 There are some other optional parameters that you can use during the `DeliveryClient` instantiation.
 
 * `$previewApiKey` – sets the Delivery Preview API key. The client will automatically start using the preview endpoint for querying. See [previewing unpublished content](#previewing-unpublished-content).
+* `$securedProductionApiKey` – sets the production Delivery API key (do not combine it with the Delivery Preview API key)
 * `$waitForLoadingNewContent` – makes the client instance wait while fetching updated content, useful when acting upon [webhook calls](https://developer.kenticocloud.com/docs/webhooks#section-requesting-new-content).
 * `$debugRequests` – switches the HTTP client to debug mode
 

--- a/tests/E2E/DeliveryClientTest.php
+++ b/tests/E2E/DeliveryClientTest.php
@@ -93,7 +93,7 @@ class DeliveryClientTest extends TestCase
 
     public function testWebhooks()
     {
-        $client = new DeliveryClient($this->getProjectId(), null, true);
+        $client = new DeliveryClient($this->getProjectId(), null, null, true);
         $item = $client->getItem('home');
         $this->assertArrayHasKey('X-KC-Wait-For-Loading-New-Content', $client->lastRequest->headers);
     }

--- a/tests/Unit/DeliveryClientTest.php
+++ b/tests/Unit/DeliveryClientTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace KenticoCloud\Tests\Unit;
+
+use KenticoCloud\Delivery\DeliveryClient;
+
+use PHPUnit\Framework\TestCase;
+use Httpful\Request;
+
+use InvalidArgumentException;
+
+class DeliveryClientTest extends TestCase
+{
+    public function getProjectId()
+    {
+        return '975bf280-fd91-488c-994c-2f04416e5ee3';
+    }
+
+    public function test_ctor_securityAndProductionSet_ExceptionThrown()
+    {
+        $securityKey = "securityKey";
+        $previewKey = "previewKey";
+        
+        $this->expectException(InvalidArgumentException::class);
+        $client = new DeliveryClient($this->getProjectId(), $previewKey, $securityKey);
+    }
+
+    public function test_ctor_previewKeyIsSetInHeaders()
+    {
+        $previewKey = "previewKey";
+        $client = new DeliveryClient($this->getProjectId(), "previewKey");
+        $authorizationHeaderValue = Request::d("headers")["Authorization"];
+
+        $this->assertEquals("Bearer ". $previewKey, $authorizationHeaderValue);
+    }
+
+    public function test_ctor_securityKeyIsSetInHeaders()
+    {
+        $securityKey = "securityKey";
+        $client = new DeliveryClient($this->getProjectId(), null, $securityKey);
+        $authorizationHeaderValue = Request::d("headers")["Authorization"];
+
+        $this->assertEquals("Bearer ". $securityKey, $authorizationHeaderValue);
+    }
+}


### PR DESCRIPTION
Fixes #32 

- Added new parameter to the DeliveryClient to be able to provide Security Key
- Covered preview API key and Secured production API key by tests (checked request headers)
- Raised version to 1.1.0

After merging the pull request follow instruction below and release version 1.1.0
https://github.com/Kentico/delivery-sdk-php/wiki/How-to-publish-new-release