### PR TITLE
Use PHP 7.3 compatible html dom parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
   
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.0",
         "nategood/httpful": "^0.2.20",
-        "sunra/php-simple-html-dom-parser": "^1.5"
+        "kub-at/php-simple-html-dom-parser": "^1.9"
     },
     "require-dev": {
         "phpdocumentor/phpdocumentor": "2.*",

--- a/src/KenticoCloud/Delivery/ModelBinder.php
+++ b/src/KenticoCloud/Delivery/ModelBinder.php
@@ -6,7 +6,7 @@
 namespace KenticoCloud\Delivery;
 
 use KenticoCloud\Delivery\Models\Items\ContentLink;
-use Sunra\PhpSimple\HtmlDomParser;
+use KubAT\PhpSimple\HtmlDomParser;
 
 /**
  * Class ModelBinder.


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #79

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Use `DeliveryClient::getItem()` on a PHP 7.3 system. It should not throw tons of warnings.

The sunra package for php-simple-html-dom-parser is not being actively maintained. This PR changes it to another package which is maintained. It still uses the same underlying code from Sourceforge, but a later version which has fixes for PHP 7.3.
