### PR TITLE
Fix PHP 8.2+ deprecation notices

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -2,7 +2,7 @@ name: Build & Test & Report
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:        
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         phpunit-versions: ['latest']
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.0 || ^8.0",
-        "nategood/httpful": "^0.2.20",
+        "nategood/httpful": "^0.2.20 || ^0.3 || ^1.0",
         "kub-at/php-simple-html-dom-parser": "^1.9"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="tests/bootstrap.php"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  convertErrorsToExceptions="true"
+  convertWarningsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertDeprecationsToExceptions="true"
+>
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">src</directory>

--- a/src/Kontent/Ai/Delivery/DeliveryClient.php
+++ b/src/Kontent/Ai/Delivery/DeliveryClient.php
@@ -7,6 +7,7 @@ namespace Kontent\Ai\Delivery;
 
 use Httpful\Request;
 use Httpful\Http;
+use Httpful\Response;
 use Kontent\Ai\Delivery\Models\Shared\Pagination;
 use InvalidArgumentException;
 use Exception;
@@ -72,7 +73,22 @@ class DeliveryClient
      */
     public $modelBinder = null;
 
-    /**
+	/**
+	 * Last request made
+	 *
+	 * @var Request|null
+	 */
+	public $lastRequest;
+
+	/**
+	 * Response from last request made
+	 *
+	 * @var Response
+	 */
+	public $lastResponse;
+
+
+	/**
      * Creates a new instance of DeliveryClient.
      *
      * @param string $projectId                Kontent.ai Delivery API Project ID

--- a/src/Kontent/Ai/Delivery/Models/Items/ContentItem.php
+++ b/src/Kontent/Ai/Delivery/Models/Items/ContentItem.php
@@ -8,6 +8,7 @@ namespace Kontent\Ai\Delivery\Models\Items;
 /**
  * Class ContentItem.
  */
+#[\AllowDynamicProperties]
 class ContentItem
 {
 }

--- a/src/Kontent/Ai/Delivery/QueryParams.php
+++ b/src/Kontent/Ai/Delivery/QueryParams.php
@@ -370,6 +370,7 @@ class QueryParams implements \ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
+	#[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -387,7 +388,7 @@ class QueryParams implements \ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
@@ -398,6 +399,7 @@ class QueryParams implements \ArrayAccess
      *
      * @param mixed $offset
      */
+	#[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);
@@ -411,6 +413,7 @@ class QueryParams implements \ArrayAccess
      *
      * @return mixed|null
      */
+	#[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;

--- a/tests/Official/CodeExampleTest.php
+++ b/tests/Official/CodeExampleTest.php
@@ -8,7 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 class CodeExamplesTests extends TestCase
 {
-    protected function setUp(): void
+	/** @var DeliveryClient */
+	private $client;
+
+
+	protected function setUp(): void
     {
         $this->client = new DeliveryClient('975bf280-fd91-488c-994c-2f04416e5ee3');
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+error_reporting(E_ALL);
+
 foreach (glob(__DIR__ . '/E2E/*Model.php') as $filename)
 {
     require_once $filename;


### PR DESCRIPTION
### Motivation

On PHP 8.2+ there are deprecations thrown when using [dynamic properties](https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.dynamic-properties) and [when overriding internal methods](https://www.php.net/manual/en/class.returntypewillchange.php). This PR fixes that.

In some projects (as is our case) the latter notices are converted into exceptions and this library needs patching to work.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Automatic tests for deprecation notices are added in this PR.
